### PR TITLE
shinano: update codecs from CAF

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -23,6 +23,7 @@ SONY_ROOT := device/sony/shinano/rootdir
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/system/etc/audio_platform_info.xml:system/etc/audio_platform_info.xml \
     $(SONY_ROOT)/system/etc/media_codecs.xml:system/etc/media_codecs.xml \
+    $(SONY_ROOT)/system/etc/media_codecs_performance.xml:system/etc/media_codecs_performance.xml \
     $(SONY_ROOT)/system/etc/media_profiles.xml:system/etc/media_profiles.xml
 
 # Broadcom BT

--- a/rootdir/system/etc/media_codecs.xml
+++ b/rootdir/system/etc/media_codecs.xml
@@ -1,5 +1,7 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright 2013 The Android Open Source Project
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2012-2013 The Android Open Source Project
+     Copyright (C) 2014 The Linux Foundation. All rights reserved.
+     Not a contribution.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,114 +16,235 @@
      limitations under the License.
 -->
 
+<!--
+8974 Encoder capabilities
+ ______________________________________________________
+ | Codec    | W       H       fps     Mbps    MB/s    |
+ |__________|_________________________________________|
+ | h264     | 3840    2160    30      100     972000  |
+ |          | 4096    2160    24      100     829440  |
+ | mpeg4    | 1920    1088    30      40      244800  |
+ | vp8      | 1920    1088    30      20      244800  |
+ | h263     | 864     480     30      2       48600   |
+ |__________|_________________________________________|
+
+ 8974 Decoder capabilities
+ ______________________________________________________
+ | Codec    | W       H       fps     Mbps    MB/s    |
+ |__________|_________________________________________|
+ | h264     | 3840    2160    30      100     972000  |
+ |          | 4096    2160    24      100     829440  |
+ | hevc     | 1280    720     30      2       108000  |
+ | hevchybd | 1920    1088    30      6       244800  |
+ | mpeg4    | 1920    1088    60      60      489600  |
+ | vc1      | 1920    1088    60      60      489600  |
+ | vp8      | 3820    2160    30      20      972000  |
+ | divx3    | 720     480     30      2       40500   |
+ | div4/5/6 | 1920    1088    30      10      244800  |
+ | h263     | 864     480     30      2       48600   |
+ | mpeg2    | 1920    1088    30      40      244800  |
+ |__________|_________________________________________|
+
+-->
+
 <MediaCodecs>
-    <Include href="media_codecs_google_audio.xml" />
-    <Include href="media_codecs_google_telephony.xml" />
+    <Include href="media_codecs_google_audio.xml"/>
+    <Include href="media_codecs_google_telephony.xml"/>
     <Settings>
-        <Setting name="max-video-encoder-input-buffers" value="9" />
+        <Setting name="max-video-encoder-input-buffers" value="9"/>
     </Settings>
     <Encoders>
-        <MediaCodec name="OMX.qcom.video.encoder.mpeg4" type="video/mp4v-es" >
-            <Quirk name="requires-allocate-on-input-ports" />
+        <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc">
+            <Quirk name="requires-allocate-on-input-ports"/>
             <Quirk name="requires-allocate-on-output-ports"/>
             <Quirk name="requires-loaded-to-idle-after-allocation"/>
-            <Limit name="size" min="96x64" max="1920x1088" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="489600" />
-            <Limit name="bitrate" range="1-60000000" />
-            <Limit name="concurrent-instances" max="13" />
+            <Limit name="size" min="96x64" max="4096x2160"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="972000"/>
+            <Limit name="bitrate" range="1-100000000"/>
+            <Limit name="concurrent-instances" max="13"/>
         </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.encoder.h263" type="video/3gpp" >
-            <Quirk name="requires-allocate-on-input-ports" />
+        <MediaCodec name="OMX.qcom.video.encoder.mpeg4" type="video/mp4v-es">
+            <Quirk name="requires-allocate-on-input-ports"/>
             <Quirk name="requires-allocate-on-output-ports"/>
             <Quirk name="requires-loaded-to-idle-after-allocation"/>
-            <Limit name="size" min="96x64" max="720x576" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="concurrent-instances" max="13" />
+            <Limit name="size" min="96x64" max="1920x1088"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="244800"/>
+            <Limit name="bitrate" range="1-40000000"/>
+            <Limit name="concurrent-instances" max="13"/>
         </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc" >
-            <Quirk name="requires-allocate-on-input-ports" />
+        <MediaCodec name="OMX.qcom.video.encoder.h263" type="video/3gpp">
+            <Quirk name="requires-allocate-on-input-ports"/>
             <Quirk name="requires-allocate-on-output-ports"/>
             <Quirk name="requires-loaded-to-idle-after-allocation"/>
-            <Limit name="size" min="96x64" max="3840x2160" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="972000" />
-            <Limit name="bitrate" range="1-100000000" />
-            <Limit name="concurrent-instances" max="13" />
+            <Limit name="size" min="96x64" max="864x480"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="48600"/>
+            <Limit name="bitrate" range="1-2000000"/>
+            <Limit name="concurrent-instances" max="13"/>
         </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.encoder.vp8" type="video/x-vnd.on2.vp8" >
-            <Quirk name="requires-allocate-on-input-ports" />
+        <MediaCodec name="OMX.qcom.video.encoder.vp8" type="video/x-vnd.on2.vp8">
+            <Quirk name="requires-allocate-on-input-ports"/>
             <Quirk name="requires-allocate-on-output-ports"/>
             <Quirk name="requires-loaded-to-idle-after-allocation"/>
-            <Limit name="size" min="96x64" max="3840x2160" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="777600" />
-            <Limit name="bitrate" range="1-20000000" />
-            <Limit name="concurrent-instances" max="13" />
+            <Limit name="size" min="96x64" max="1920x1088"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="244800"/>
+            <Limit name="bitrate" range="1-20000000"/>
+            <Limit name="concurrent-instances" max="13"/>
         </MediaCodec>
     </Encoders>
     <Decoders>
-        <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" >
-            <Quirk name="requires-allocate-on-input-ports" />
+        <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc">
+            <Quirk name="requires-allocate-on-input-ports"/>
             <Quirk name="requires-allocate-on-output-ports"/>
-            <Quirk name="defers-output-buffer-allocation"/>
-            <Limit name="size" min="64x64" max="3840x2160" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="972000" />
-            <Limit name="bitrate" range="1-100000000" />
-            <Feature name="adaptive-playback" />
-            <Limit name="concurrent-instances" max="13" />
+            <Limit name="size" min="64x64" max="4096x2160"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="972000"/>
+            <Limit name="bitrate" range="1-100000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="13"/>
         </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.decoder.avc.secure" type="video/avc" >
-            <Quirk name="requires-allocate-on-input-ports" />
+        <MediaCodec name="OMX.qcom.video.decoder.avc.secure" type="video/avc">
+            <Quirk name="requires-allocate-on-input-ports"/>
             <Quirk name="requires-allocate-on-output-ports"/>
-            <Quirk name="defers-output-buffer-allocation"/>
-            <Limit name="size" min="64x64" max="3840x2160" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="972000" />
-            <Limit name="bitrate" range="1-100000000" />
-            <Feature name="adaptive-playback" />
-            <Feature name="secure-playback" required="true" />
-            <Limit name="concurrent-instances" max="6" />
+            <Limit name="size" min="64x64" max="4096x2160"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="972000"/>
+            <Limit name="bitrate" range="1-100000000"/>
+            <Feature name="adaptive-playback"/>
+            <Feature name="secure-playback" required="true"/>
+            <Limit name="concurrent-instances" max="4"/>
         </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.decoder.mpeg4" type="video/mp4v-es" >
-            <Quirk name="requires-allocate-on-input-ports" />
+        <MediaCodec name="OMX.qcom.video.decoder.mpeg2" type="video/mpeg2">
+            <Quirk name="requires-allocate-on-input-ports"/>
             <Quirk name="requires-allocate-on-output-ports"/>
-            <Quirk name="defers-output-buffer-allocation"/>
-            <Limit name="size" min="64x64" max="1920x1088" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="489600" />
-            <Limit name="bitrate" range="1-60000000" />
-            <Feature name="adaptive-playback" />
-            <Limit name="concurrent-instances" max="13" />
+            <Limit name="size" min="96x64" max="1920x1088"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="244800"/>
+            <Limit name="bitrate" range="1-40000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="13"/>
         </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.decoder.h263" type="video/3gpp" >
-            <Quirk name="requires-allocate-on-input-ports" />
+        <MediaCodec name="OMX.qcom.video.decoder.mpeg2.secure" type="video/mpeg2">
+            <Quirk name="requires-allocate-on-input-ports"/>
             <Quirk name="requires-allocate-on-output-ports"/>
-            <Quirk name="defers-output-buffer-allocation"/>
-            <Limit name="size" min="64x64" max="720x576" />
-            <Limit name="alignment" value="2x2" />
-            <Feature name="adaptive-playback" />
-            <Limit name="concurrent-instances" max="13" />
+            <Limit name="size" min="96x64" max="1920x1088"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="244800"/>
+            <Limit name="bitrate" range="1-40000000"/>
+            <Feature name="adaptive-playback"/>
+            <Feature name="secure-playback" required="true"/>
+            <Limit name="concurrent-instances" max="13"/>
         </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.decoder.vp8" type="video/x-vnd.on2.vp8" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-            <Quirk name="defers-output-buffer-allocation" />
-            <Limit name="size" min="64x64" max="3840x2160" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="777600" />
-            <Limit name="bitrate" range="1-20000000" />
-            <Feature name="adaptive-playback" />
-            <Limit name="concurrent-instances" max="13" />
+        <MediaCodec name="OMX.qcom.video.decoder.mpeg4" type="video/mp4v-es">
+            <Quirk name="requires-allocate-on-input-ports"/>
+            <Quirk name="requires-allocate-on-output-ports"/>
+            <Limit name="size" min="64x64" max="1920x1088"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="489600"/>
+            <Limit name="bitrate" range="1-60000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="13"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.h263" type="video/3gpp">
+            <Quirk name="requires-allocate-on-input-ports"/>
+            <Quirk name="requires-allocate-on-output-ports"/>
+            <Limit name="size" min="64x64" max="864x480"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="48600"/>
+            <Limit name="bitrate" range="1-2000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="13"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.vc1" type="video/x-ms-wmv">
+            <Quirk name="requires-allocate-on-input-ports"/>
+            <Quirk name="requires-allocate-on-output-ports"/>
+            <Limit name="size" min="64x64" max="1920x1088"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="489600"/>
+            <Limit name="bitrate" range="1-60000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="13"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.divx" type="video/divx">
+            <Quirk name="requires-allocate-on-input-ports"/>
+            <Quirk name="requires-allocate-on-output-ports"/>
+            <Limit name="size" min="64x64" max="1920x1088"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="244800"/>
+            <Limit name="bitrate" range="1-10000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="13"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.divx311" type="video/divx311">
+            <Quirk name="requires-allocate-on-input-ports"/>
+            <Quirk name="requires-allocate-on-output-ports"/>
+            <Limit name="size" min="64x64" max="720x480"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="40500"/>
+            <Limit name="bitrate" range="1-2000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="13"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.divx4" type="video/divx4">
+            <Quirk name="requires-allocate-on-input-ports"/>
+            <Quirk name="requires-allocate-on-output-ports"/>
+            <Limit name="size" min="64x64" max="1920x1088"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="244800"/>
+            <Limit name="bitrate" range="1-10000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="13"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.vp8" type="video/x-vnd.on2.vp8">
+            <Quirk name="requires-allocate-on-input-ports"/>
+            <Quirk name="requires-allocate-on-output-ports"/>
+            <Limit name="size" min="64x64" max="3840x2160"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="972000"/>
+            <Limit name="bitrate" range="1-20000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="13"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.hevc" type="video/hevc">
+            <Quirk name="requires-allocate-on-input-ports"/>
+            <Quirk name="requires-allocate-on-output-ports"/>
+            <Limit name="size" min="64x64" max="1280x720"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="108000"/>
+            <Limit name="bitrate" range="1-2000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="3"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.hevchybrid" type="video/hevc">
+            <Quirk name="requires-allocate-on-input-ports"/>
+            <Quirk name="requires-allocate-on-output-ports"/>
+            <Limit name="size" min="64x64" max="1920x1088"/>
+            <Limit name="alignment" value="2x2"/>
+            <Limit name="block-size" value="16x16"/>
+            <Limit name="blocks-per-second" min="1" max="244800"/>
+            <Limit name="bitrate" range="1-6000000"/>
+            <Feature name="adaptive-playback"/>
+            <Limit name="concurrent-instances" max="2"/>
         </MediaCodec>
     </Decoders>
-    <Include href="media_codecs_google_video.xml" />
+    <Include href="media_codecs_google_video.xml"/>
 </MediaCodecs>

--- a/rootdir/system/etc/media_codecs_performance.xml
+++ b/rootdir/system/etc/media_codecs_performance.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (c) 2015, The Linux Foundation. All rights reserved.
+
+     Not a Contribution.
+
+     Copyright 2015 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<MediaCodecs>
+    <Encoders>
+        <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="561-561"/>
+            <Limit name="measured-frame-rate-720x480" range="281-281"/>
+            <Limit name="measured-frame-rate-1280x720" range="123-123"/>
+            <Limit name="measured-frame-rate-1920x1080" range="78-78"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.h263" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="462-462"/>
+            <Limit name="measured-frame-rate-352x288" range="291-291"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.mpeg4" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="502-502"/>
+            <Limit name="measured-frame-rate-352x288" range="312-312"/>
+            <Limit name="measured-frame-rate-640x480" range="174-174"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.vp8" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="93-93"/>
+            <Limit name="measured-frame-rate-640x360" range="90-90"/>
+            <Limit name="measured-frame-rate-1280x720" range="79-79"/>
+            <Limit name="measured-frame-rate-1920x1080" range="42-42"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h264.encoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="387-387"/>
+            <Limit name="measured-frame-rate-720x480" range="237-237"/>
+            <Limit name="measured-frame-rate-1280x720" range="108-108"/>
+            <Limit name="measured-frame-rate-1920x1080" range="45-45"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h263.encoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="900-900"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.google.mpeg4.encoder" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-176x144" range="1145-1145"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.google.vp8.encoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x180" range="461-461"/>
+            <Limit name="measured-frame-rate-640x360" range="214-214"/>
+            <Limit name="measured-frame-rate-1280x720" range="99-99"/>
+            <Limit name="measured-frame-rate-1920x1080" range="39-39"/>
+        </MediaCodec>
+    </Encoders>
+    <Decoders>
+        <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="453-453"/>
+            <Limit name="measured-frame-rate-720x480" range="249-249"/>
+            <Limit name="measured-frame-rate-1280x720" range="103-103"/>
+            <Limit name="measured-frame-rate-1920x1088" range="46-46"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.h263" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="1089-1089"/>
+            <Limit name="measured-frame-rate-352x288" range="842-842"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.mpeg4" type="video/mp4v-es" update="true">
+            <Limit name="measured-frame-rate-480x360" range="798-798"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.decoder.vp8" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x240" range="210-210"/>
+            <Limit name="measured-frame-rate-640x360" range="191-191"/>
+            <Limit name="measured-frame-rate-1280x720" range="537-537"/>
+            <Limit name="measured-frame-rate-1920x1080" range="325-325"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h264.decoder" type="video/avc" update="true">
+            <Limit name="measured-frame-rate-320x240" range="396-396"/>
+            <Limit name="measured-frame-rate-720x480" range="279-279"/>
+            <Limit name="measured-frame-rate-1280x720" range="138-138"/>
+            <Limit name="measured-frame-rate-1920x1080" range="41-41"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.google.h263.decoder" type="video/3gpp" update="true">
+            <Limit name="measured-frame-rate-176x144" range="1200-1200"/>
+            <Limit name="measured-frame-rate-352x288" range="923-923"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.google.hevc.decoder" type="video/hevc" update="true">
+            <Limit name="measured-frame-rate-352x288" range="1883-1883"/>
+            <Limit name="measured-frame-rate-720x480" range="516-516"/>
+            <Limit name="measured-frame-rate-1280x720" range="234-234"/>
+            <Limit name="measured-frame-rate-1920x1080" range="106-106"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.google.vp8.decoder" type="video/x-vnd.on2.vp8" update="true">
+            <Limit name="measured-frame-rate-320x240" range="1644-1644"/>
+            <Limit name="measured-frame-rate-640x360" range="513-513"/>
+            <Limit name="measured-frame-rate-1280x720" range="106-106"/>
+            <Limit name="measured-frame-rate-1920x1080" range="93-93"/>
+        </MediaCodec>
+        <MediaCodec name="OMX.google.vp9.decoder" type="video/x-vnd.on2.vp9" update="true">
+            <Limit name="measured-frame-rate-320x240" range="535-535"/>
+            <Limit name="measured-frame-rate-640x360" range="480-480"/>
+            <Limit name="measured-frame-rate-1280x720" range="144-144"/>
+            <Limit name="measured-frame-rate-1920x1080" range="95-95"/>
+        </MediaCodec>
+    </Decoders>
+</MediaCodecs>

--- a/rootdir/system/etc/media_profiles.xml
+++ b/rootdir/system/etc/media_profiles.xml
@@ -79,65 +79,65 @@
     <!-- Each camcorder profile defines a set of predefined configuration parameters -->
     <CamcorderProfiles cameraId="0">
 
-        <EncoderProfile quality="qvga" fileFormat="3gp" duration="60">
-            <Video codec="m4v"
-                   bitRate="128000"
+        <EncoderProfile quality="qvga" fileFormat="mp4" duration="60">
+            <Video codec="h264"
+                   bitRate="512000"
                    width="320"
                    height="240"
-                   frameRate="15" />
+                   frameRate="30" />
+            <Audio codec="aac"
+                   bitRate="156000"
+                   sampleRate="48000"
+                   channels="2" />
+        </EncoderProfile>
+
+        <EncoderProfile quality="cif" fileFormat="3gp" duration="30">
+            <Video codec="h264"
+                   bitRate="720000"
+                   width="352"
+                   height="288"
+                   frameRate="30" />
             <Audio codec="amrnb"
                    bitRate="12200"
                    sampleRate="8000"
                    channels="1" />
         </EncoderProfile>
 
-        <EncoderProfile quality="cif" fileFormat="mp4" duration="30">
-            <Video codec="h264"
-                   bitRate="1200000"
-                   width="352"
-                   height="288"
-                   frameRate="30" />
-            <Audio codec="aac"
-                   bitRate="96000"
-                   sampleRate="48000"
-                   channels="1" />
-        </EncoderProfile>
-
         <EncoderProfile quality="480p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="6000000"
-                   width="640"
+                   bitRate="2000000"
+                   width="720"
                    height="480"
                    frameRate="30" />
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
 
         <EncoderProfile quality="720p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="12000000"
+                   bitRate="14000000"
                    width="1280"
                    height="720"
                    frameRate="30" />
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
 
         <!--
         <EncoderProfile quality="1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="17000000"
+                   bitRate="20000000"
                    width="1920"
                    height="1080"
                    frameRate="30" />
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
         -->
 
@@ -156,47 +156,47 @@
 
         <EncoderProfile quality="timelapsecif" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="1200000"
+                   bitRate="720000"
                    width="352"
                    height="288"
                    frameRate="30" />
             <!-- audio setting is ignored -->
-            <Audio codec="aac"
-                   bitRate="96000"
-                   sampleRate="48000"
+            <Audio codec="amrnb"
+                   bitRate="12200"
+                   sampleRate="8000"
                    channels="1" />
         </EncoderProfile>
 
         <EncoderProfile quality="timelapse480p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="6000000"
-                   width="720"
+                   bitRate="2000000"
+                   width="640"
                    height="480"
                    frameRate="30" />
             <!-- audio setting is ignored -->
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
 
         <EncoderProfile quality="timelapse720p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="12000000"
+                   bitRate="14000000"
                    width="1280"
                    height="720"
                    frameRate="30" />
             <!-- audio setting is ignored -->
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
 
         <!--
         <EncoderProfile quality="timelapse1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="17000000"
+                   bitRate="20000000"
                    width="1920"
                    height="1080"
                    frameRate="30" />
@@ -204,9 +204,9 @@
             <!-- audio setting is ignored -->
         <!--
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
         -->
 
@@ -219,65 +219,65 @@
 
     <CamcorderProfiles cameraId="1">
 
-        <EncoderProfile quality="qvga" fileFormat="3gp" duration="60">
-            <Video codec="m4v"
-                   bitRate="128000"
+        <EncoderProfile quality="qvga" fileFormat="mp4" duration="60">
+            <Video codec="h264"
+                   bitRate="512000"
                    width="320"
                    height="240"
-                   frameRate="15" />
+                   frameRate="30" />
+            <Audio codec="aac"
+                   bitRate="156000"
+                   sampleRate="48000"
+                   channels="2" />
+        </EncoderProfile>
+
+        <EncoderProfile quality="cif" fileFormat="3gp" duration="30">
+            <Video codec="h264"
+                   bitRate="720000"
+                   width="352"
+                   height="288"
+                   frameRate="30" />
             <Audio codec="amrnb"
                    bitRate="12200"
                    sampleRate="8000"
                    channels="1" />
         </EncoderProfile>
 
-        <EncoderProfile quality="cif" fileFormat="mp4" duration="30">
-            <Video codec="h264"
-                   bitRate="1200000"
-                   width="352"
-                   height="288"
-                   frameRate="30" />
-            <Audio codec="aac"
-                   bitRate="96000"
-                   sampleRate="48000"
-                   channels="1" />
-        </EncoderProfile>
-
         <EncoderProfile quality="480p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="6000000"
-                   width="640"
+                   bitRate="2000000"
+                   width="720"
                    height="480"
                    frameRate="30" />
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
 
         <EncoderProfile quality="720p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="12000000"
+                   bitRate="14000000"
                    width="1280"
                    height="720"
                    frameRate="30" />
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
 
         <!--
         <EncoderProfile quality="1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="17000000"
+                   bitRate="20000000"
                    width="1920"
                    height="1080"
                    frameRate="30" />
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
         -->
 
@@ -309,7 +309,7 @@
 
         <EncoderProfile quality="timelapse480p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="6000000"
+                   bitRate="5000000"
                    width="720"
                    height="480"
                    frameRate="30" />
@@ -322,7 +322,7 @@
 
         <EncoderProfile quality="timelapse720p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="12000000"
+                   bitRate="8000000"
                    width="1280"
                    height="720"
                    frameRate="30" />
@@ -336,7 +336,7 @@
         <!--
         <EncoderProfile quality="timelapse1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
-                   bitRate="17000000"
+                   bitRate="20000000"
                    width="1920"
                    height="1080"
                    frameRate="30" />
@@ -344,9 +344,9 @@
             <!-- audio setting is ignored -->
         <!--
             <Audio codec="aac"
-                   bitRate="96000"
+                   bitRate="156000"
                    sampleRate="48000"
-                   channels="1" />
+                   channels="2" />
         </EncoderProfile>
         -->
 
@@ -366,27 +366,33 @@
          or query the capabilities of the codec at all if it is disabled
     -->
     <VideoEncoderCap name="h264" enabled="true"
-        minBitRate="64000" maxBitRate="40000000"
-        minFrameWidth="176" maxFrameWidth="1920"
-        minFrameHeight="144" maxFrameHeight="1080"
-        minFrameRate="15" maxFrameRate="30" />
+        minBitRate="64000" maxBitRate="100000000"
+        minFrameWidth="176" maxFrameWidth="4096"
+        minFrameHeight="144" maxFrameHeight="2160"
+        minFrameRate="15" maxFrameRate="30"
+        maxHFRFrameWidth="1920" maxHFRFrameHeight="1080"
+        maxHFRMode="120"  />
 
     <VideoEncoderCap name="h263" enabled="true"
         minBitRate="64000" maxBitRate="2000000"
         minFrameWidth="176" maxFrameWidth="800"
         minFrameHeight="144" maxFrameHeight="480"
-        minFrameRate="15" maxFrameRate="30" />
+        minFrameRate="15" maxFrameRate="30"
+        maxHFRFrameWidth="0" maxHFRFrameHeight="0"
+        maxHFRMode="0"  />
 
     <VideoEncoderCap name="m4v" enabled="true"
-        minBitRate="64000" maxBitRate="40000000"
+        minBitRate="64000" maxBitRate="20000000"
         minFrameWidth="176" maxFrameWidth="1920"
-        minFrameHeight="144" maxFrameHeight="1080"
-        minFrameRate="15" maxFrameRate="30" />
+        minFrameHeight="144" maxFrameHeight="1088"
+        minFrameRate="15" maxFrameRate="30"
+        maxHFRFrameWidth="0" maxHFRFrameHeight="0"
+        maxHFRMode="0"  />
 
     <AudioEncoderCap name="aac" enabled="true"
-        minBitRate="758" maxBitRate="288000"
+        minBitRate="8000" maxBitRate="96000"
         minSampleRate="8000" maxSampleRate="48000"
-        minChannels="1" maxChannels="1" />
+        minChannels="1" maxChannels="6" />
 
     <AudioEncoderCap name="heaac" enabled="true"
         minBitRate="8000" maxBitRate="64000"
@@ -399,7 +405,7 @@
         minChannels="1" maxChannels="1" />
 
     <AudioEncoderCap name="amrwb" enabled="true"
-        minBitRate="6600" maxBitRate="23050"
+        minBitRate="6600" maxBitRate="23850"
         minSampleRate="16000" maxSampleRate="16000"
         minChannels="1" maxChannels="1" />
 


### PR DESCRIPTION
use latest msm8974 (cooper LA.BF.1.1.3_rb1.13)

also this fixes video recording (720p 720x480)

Signed-off-by: David Viteri <davidteri91@gmail.com>